### PR TITLE
Fix an issue with removing old listeners

### DIFF
--- a/pyromod/listen/listen.py
+++ b/pyromod/listen/listen.py
@@ -63,7 +63,7 @@ class Client():
    
     @patchable
     def clear_listener(self, chat_id, future):
-        if future == self.listening[chat_id]:
+        if future == self.listening[chat_id]["future"]:
             self.listening.pop(chat_id, None)
      
     @patchable


### PR DESCRIPTION
After the future is done it isn't removed  from the listeners list because you compared the future with the dict that contains the future instead of the dict["future"].